### PR TITLE
Update Weatherboard.py correct logic error

### DIFF
--- a/WeatherBoard.py
+++ b/WeatherBoard.py
@@ -469,8 +469,8 @@ while True:
 		if (config.OLED_Present):
 			Scroll_SSD1306.addLineOLED(display,  ("Wind Speed=\t%0.2f MPH")%(currentWindSpeed))
 			Scroll_SSD1306.addLineOLED(display,  ("Rain Total=\t%0.2f in")%(totalRain))
-  		if (config.ADS1015_Present or config.ADS1115_Present):	
-			Scroll_SSD1306.addLineOLED(display,  "Wind Dir=%0.2f Degrees" % weatherStation.current_wind_direction())
+  			if (config.ADS1015_Present or config.ADS1115_Present):	
+				Scroll_SSD1306.addLineOLED(display,  "Wind Dir=%0.2f Degrees" % weatherStation.current_wind_direction())
 
     		print("MPH wind_gust=\t%0.2f MPH")%(currentWindGust)
   		if (config.ADS1015_Present or config.ADS1115_Present):	


### PR DESCRIPTION
Line 472-473 has a logic error - you can't write to the OLED if no OLED is present.  Needed one additional indentation in both lines to make the second if statement a sub-statement of the previous if statement